### PR TITLE
Readme: Fix links

### DIFF
--- a/slim/README.md
+++ b/slim/README.md
@@ -1,7 +1,7 @@
 # README
 
-Slim language support for Visual Studio Code based on [https://github.com/slim-template/ruby-slim.tmbundle]
+Slim language support for Visual Studio Code based on [github.com/slim-template/ruby-slim.tmbundle](https://github.com/slim-template/ruby-slim.tmbundle)
 
-Visual Studio Marketplace page: [https://marketplace.visualstudio.com/items?itemName=sianglim.slim]
+Visual Studio Marketplace page: [marketplace.visualstudio.com/items?itemName=sianglim.slim](https://marketplace.visualstudio.com/items?itemName=sianglim.slim)
 
-Help make this extension better at [https://github.com/sianglim/vscode-slim]
+Help make this extension better at [github.com/sianglim/vscode-slim](https://github.com/sianglim/vscode-slim)


### PR DESCRIPTION
Explicitly specifying link text and link url. The markdown renderer inside of VS Code adds the closing `]` to the URL which results in broken URLs like `https://github.com/sianglim/vscode-slim%5D`.

<img width="837" alt="Bildschirmfoto 2021-06-08 um 13 06 39" src="https://user-images.githubusercontent.com/111561/121174880-b4270500-c85a-11eb-8043-76620d56a7f2.png">
